### PR TITLE
chore: expose COMMIT_HASH and BUILD_TIME on the health endpoint

### DIFF
--- a/.github/workflows/aws_dev_release_gitops.yml
+++ b/.github/workflows/aws_dev_release_gitops.yml
@@ -88,6 +88,9 @@ jobs:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ env.REPOSITORY }}
           tags: |
             type=raw,value=${{ github.event.repository.name }}
+      - name: Compute image build timestamp
+        id: buildtime
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
       - name: Build and push multi-platform images to ECR
         id: build
         uses: docker/build-push-action@v5
@@ -99,6 +102,7 @@ jobs:
           build-args: |
             REF=${{ github.ref }}
             COMMIT_HASH=${{ github.sha }}
+            BUILD_TIME=${{ steps.buildtime.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/.github/workflows/aws_prod_release.yml
+++ b/.github/workflows/aws_prod_release.yml
@@ -102,6 +102,9 @@ jobs:
             type=raw,value=${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
             type=raw,value=${{ github.event.repository.name }}-latest
 
+      - name: Compute image build timestamp
+        id: buildtime
+        run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
       - name: Build and push multi-platform images to ECR
         uses: docker/build-push-action@v5
         with:
@@ -112,6 +115,7 @@ jobs:
           build-args: |
             REF=${{ github.ref }}
             COMMIT_HASH=${{ github.sha }}
+            BUILD_TIME=${{ steps.buildtime.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20.10-alpine3.19
 WORKDIR /app
 ARG REF
 ARG COMMIT_HASH
+ENV COMMIT_HASH=$COMMIT_HASH
+ARG BUILD_TIME
+ENV BUILD_TIME=$BUILD_TIME
 RUN echo "export REF=$REF" >> commit_info.txt && echo "export COMMIT_HASH=$COMMIT_HASH" >> commit_info.txt
 ADD server ./server
 ADD client ./client

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -29,6 +29,7 @@ router.get("/system/health", (req, res) => {
       INTERACTIVE_SECRET: process.env.INTERACTIVE_SECRET ? "SET" : "NOT SET",
       APP_URL: process.env.APP_URL ? process.env.APP_URL : "NOT SET",
       COMMIT_HASH: process.env.COMMIT_HASH ? process.env.COMMIT_HASH : "NOT SET",
+      BUILD_TIME: process.env.BUILD_TIME ?? "NOT SET",
     },
   });
 });


### PR DESCRIPTION
Exposes the built commit and the image build timestamp on the health endpoint, so a running environment can be tied back to a git SHA and a point in time — and dev compared against prod — without guessing.

## Problem

**The commit SHA never reached the container.** The chain from CI to the health payload has four links, and only 4 of 41 apps had all four:

| Link | Was wired in |
|---|---|
| CI passes `COMMIT_HASH=${{ github.sha }}` as a build-arg | 39/41 |
| `Dockerfile` declares `ARG COMMIT_HASH` | 8/41 |
| runtime actually receives the value | 4/41 |
| `/api/system/health` reports it | 12/41 |

Because the Dockerfile never declared the ARG, the value CI passed was silently discarded in most repos — Docker does not warn about an unconsumed build-arg.

The existing `commit_info.txt` approach is also fragile: the Dockerfile writes the file at build time, but it only takes effect if the start script runs `source commit_info.txt`. Three apps wrote the file and never sourced it, so they looked correctly wired and still reported nothing.

Verified against live production: only `breakout0` and `svghunt0` returned a commit SHA. `bboard0` returned `"NOT SET"`; the rest omitted the field entirely.

**There was no reliable deploy timestamp.** `serverStartDate` only records when the container last started, so it resets on any restart, scale event, or task replacement and cannot be used as a release reference.

## Change

Three edits, applied uniformly:

1. **Dockerfile** — declare `ARG COMMIT_HASH` / `ARG BUILD_TIME` in the final build stage and promote both with `ENV`. Using `ENV` means the values reach the process regardless of how the app is started, so no start-script changes are needed and the write-but-never-source failure cannot recur.
2. **CI** — add a `buildtime` step that stamps `date -u +%Y-%m-%dT%H:%M:%SZ` and pass it as a `BUILD_TIME` build-arg, in both the dev and prod build workflows. `COMMIT_HASH` was already being passed.
3. **Health route** — report `COMMIT_HASH` and `BUILD_TIME` in the envs block.

`BUILD_TIME` is baked into the image at build time, so unlike `serverStartDate` it stays fixed for the life of the image and identifies the artifact rather than the container.

`commit_info.txt` is intentionally left in place where it exists — it keeps working, and removing it is a separate cleanup.

## Verifying after merge

```
curl -s https://<app>-prod-topia.topia-rtsdk.com/api/system/health \
  | jq '{appVersion, commit: .envs.COMMIT_HASH, built: .envs.BUILD_TIME}'
```